### PR TITLE
feat: add a level 2 prototype

### DIFF
--- a/src/fps_counter.rs
+++ b/src/fps_counter.rs
@@ -1,4 +1,7 @@
-use bevy::{dev_tools::fps_overlay::{FpsOverlayConfig, FpsOverlayPlugin}, prelude::*};
+use bevy::{
+    dev_tools::fps_overlay::{FpsOverlayConfig, FpsOverlayPlugin},
+    prelude::*,
+};
 
 pub(super) fn plugin(app: &mut App) {
     // Print state transitions in dev builds

--- a/src/game/animation.rs
+++ b/src/game/animation.rs
@@ -162,7 +162,6 @@ pub(super) fn plugin(app: &mut App) {
 //     }
 // }
 
-
 #[derive(Resource)]
 pub struct Animations {
     pub animations: Vec<AnimationNodeIndex>,

--- a/src/game/movement.rs
+++ b/src/game/movement.rs
@@ -9,7 +9,10 @@ use bevy::{prelude::*, window::PrimaryWindow};
 
 use crate::{screen::Screen, AppSet};
 
-use super::spawn::{level::{self, Level}, player::Player};
+use super::spawn::{
+    level::{self, Level},
+    player::Player,
+};
 
 pub(super) fn plugin(app: &mut App) {
     // Record directional input as movement controls.
@@ -30,15 +33,12 @@ pub(super) fn plugin(app: &mut App) {
     );
 
     // Camera tracking.
-    app.add_systems(
-        Update,
-        camera_tracking.run_if(in_state(Screen::Playing)),
-    );
+    app.add_systems(Update, camera_tracking.run_if(in_state(Screen::Playing)));
 }
 
 #[derive(Component, Reflect, Default)]
 #[reflect(Component)]
-pub struct MovementController{
+pub struct MovementController {
     pub intent: Vec2,
     pub action: bool,
 }
@@ -92,31 +92,28 @@ fn control_movement(
         match *level {
             Level::BackToLake => {
                 movement.acceleration.y = -20.0;
-                if controller.action{
+                if controller.action {
                     movement.acceleration.y = 1000.0;
                 }
-            },
+            }
             _ => {
                 let controller_acceleration = controller.intent * 50.0;
                 movement.acceleration = controller_acceleration.extend(0.0);
-            },
+            }
         }
     }
 }
 
 const MAX_SPEED: f32 = 50.0;
 
-fn update_movement(
-    time: Res<Time>,
-    mut movement_query: Query<(&mut Movement, &mut Transform)>,
-) {
+fn update_movement(time: Res<Time>, mut movement_query: Query<(&mut Movement, &mut Transform)>) {
     for (mut movement, mut transform) in &mut movement_query {
         let acceleration = movement.acceleration;
         movement.velocity += acceleration * time.delta_seconds();
 
         transform.translation += movement.velocity * time.delta_seconds();
 
-        if movement.velocity.length() > 0.0{
+        if movement.velocity.length() > 0.0 {
             let rotation = Quat::from_rotation_arc(Vec3::Z, movement.velocity.normalize());
             transform.rotation = rotation;
         }

--- a/src/game/movement.rs
+++ b/src/game/movement.rs
@@ -85,6 +85,11 @@ fn update_movement(
         movement.velocity += acceleration * time.delta_seconds();
 
         transform.translation += movement.velocity * time.delta_seconds();
+
+        if movement.velocity.length() > 0.0{
+            let rotation = Quat::from_rotation_arc(Vec3::Z, movement.velocity.normalize());
+            transform.rotation = rotation;
+        }
     }
 }
 

--- a/src/game/movement.rs
+++ b/src/game/movement.rs
@@ -3,6 +3,8 @@
 //! If you want to move the player in a smoother way,
 //! consider using a [fixed timestep](https://github.com/bevyengine/bevy/blob/latest/examples/movement/physics_in_fixed_timestep.rs).
 
+use std::ops::Deref;
+
 use bevy::{prelude::*, window::PrimaryWindow};
 
 use crate::{screen::Screen, AppSet};
@@ -87,8 +89,8 @@ fn control_movement(
     level: Res<Level>,
 ) {
     for (controller, mut movement) in &mut movement_query {
-        match level.0 {
-            2 => {
+        match *level {
+            Level::BackToLake => {
                 movement.acceleration.y = -20.0;
                 if controller.action{
                     movement.acceleration.y = 1000.0;
@@ -145,7 +147,7 @@ fn camera_tracking(
     player_query: Query<&Transform, (With<Player>, Without<Camera>)>,
     level: Res<Level>,
 ) {
-    if level.0 != 2 {
+    if level.deref() != &Level::BackToLake {
         return;
     }
 

--- a/src/game/spawn/level.rs
+++ b/src/game/spawn/level.rs
@@ -1,18 +1,48 @@
 //! Spawn the main level by triggering other observers.
 
-use bevy::prelude::*;
+use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+
+use crate::screen::Screen;
 
 use super::player::SpawnPlayer;
 
 pub(super) fn plugin(app: &mut App) {
     app.observe(spawn_level);
+
+    app.add_systems(
+        Update,
+        go_to_previous_level
+            .run_if(in_state(Screen::Playing).and_then(input_just_pressed(KeyCode::Digit1))),
+    );
+
+    app.add_systems(
+        Update,
+        go_to_next_level
+            .run_if(in_state(Screen::Playing).and_then(input_just_pressed(KeyCode::Digit2))),
+    );
 }
+
+#[derive(Resource)]
+pub struct Level(pub u8);
 
 #[derive(Event, Debug)]
 pub struct SpawnLevel;
 
-fn spawn_level(_trigger: Trigger<SpawnLevel>, mut commands: Commands) {
+fn spawn_level(_trigger: Trigger<SpawnLevel>, mut commands: Commands, level: Res<Level>) {
     // The only thing we have in our level is a player,
     // but add things like walls etc. here.
     commands.trigger(SpawnPlayer);
+    println!("Spawning level {}", level.0);
+}
+
+fn go_to_next_level(mut next_screen: ResMut<NextState<Screen>>, mut level: ResMut<Level>) {
+    level.0 += 1;
+    next_screen.set(Screen::Playing);
+}
+
+fn go_to_previous_level(mut next_screen: ResMut<NextState<Screen>>, mut level: ResMut<Level>) {
+    if level.0 > 1 {
+        level.0 -= 1;
+    }
+    next_screen.set(Screen::Playing);
 }

--- a/src/game/spawn/level.rs
+++ b/src/game/spawn/level.rs
@@ -25,12 +25,12 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 #[derive(Resource, Default, Debug, PartialEq, PartialOrd, Eq)]
-pub enum Level{
+pub enum Level {
     #[default]
     Birth,
     Ocean,
     BackToLake,
-    Death
+    Death,
 }
 
 #[derive(Event, Debug)]
@@ -58,7 +58,7 @@ fn next_level_from_enum(level: &Level) -> Level {
         Level::Birth => Level::Ocean,
         Level::Ocean => Level::BackToLake,
         Level::BackToLake => Level::Death,
-        Level::Death => Level::Birth
+        Level::Death => Level::Birth,
     }
 }
 
@@ -67,6 +67,6 @@ fn prev_level_from_enum(level: &Level) -> Level {
         Level::Birth => Level::Death,
         Level::Ocean => Level::Birth,
         Level::BackToLake => Level::Ocean,
-        Level::Death => Level::BackToLake
+        Level::Death => Level::BackToLake,
     }
 }

--- a/src/game/spawn/player.rs
+++ b/src/game/spawn/player.rs
@@ -8,7 +8,7 @@ use crate::{
     game::{animation::Animations, movement::{Movement, MovementController, WrapWithinWindow}}, screen::Screen
 };
 
-use super::level::Level;
+use super::level::{self, Level};
 
 pub(super) fn plugin(app: &mut App) {
     app.observe(spawn_player);
@@ -22,7 +22,6 @@ pub struct SpawnPlayer;
 #[reflect(Component)]
 pub struct Player;
 
-const INITIAL_VELOCITY: Vec3 = Vec3::ZERO;
 const INITIAL_POSITION: Vec3 = Vec3::ZERO;
 
 fn spawn_player(
@@ -30,7 +29,7 @@ fn spawn_player(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut graphs: ResMut<Assets<AnimationGraph>>,
-    _level: Res<Level>
+    level: Res<Level>
 ) {
     let mut scene_bundle = SceneBundle {
         transform: Transform::from_translation(INITIAL_POSITION),
@@ -53,13 +52,17 @@ fn spawn_player(
         graph: graph_handle,
         animations,
     });
-
+    let velocity = if level.0 == 1 {
+        Vec3::new(0.0, 0.0, 0.0)
+    } else {
+        Vec3::new(20.0, 0.0, 0.0)
+    };
     commands.spawn((
         Name::new("Player"),
         Player,
         scene_bundle,
         MovementController::default(),
-        Movement { velocity: INITIAL_VELOCITY, acceleration:Vec3::ZERO },
+        Movement { velocity , acceleration:Vec3::ZERO },
         WrapWithinWindow,
         StateScoped(Screen::Playing),
     ));

--- a/src/game/spawn/player.rs
+++ b/src/game/spawn/player.rs
@@ -52,7 +52,7 @@ fn spawn_player(
         graph: graph_handle,
         animations,
     });
-    let velocity = if level.0 == 1 {
+    let velocity = if *level != Level::BackToLake {
         Vec3::new(0.0, 0.0, 0.0)
     } else {
         Vec3::new(20.0, 0.0, 0.0)

--- a/src/game/spawn/player.rs
+++ b/src/game/spawn/player.rs
@@ -8,6 +8,8 @@ use crate::{
     game::{animation::Animations, movement::{Movement, MovementController, WrapWithinWindow}}, screen::Screen
 };
 
+use super::level::Level;
+
 pub(super) fn plugin(app: &mut App) {
     app.observe(spawn_player);
     app.register_type::<Player>();
@@ -28,6 +30,7 @@ fn spawn_player(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut graphs: ResMut<Assets<AnimationGraph>>,
+    _level: Res<Level>
 ) {
     let mut scene_bundle = SceneBundle {
         transform: Transform::from_translation(INITIAL_POSITION),

--- a/src/game/spawn/player.rs
+++ b/src/game/spawn/player.rs
@@ -5,7 +5,11 @@ use std::f32::consts::PI;
 use bevy::prelude::*;
 
 use crate::{
-    game::{animation::Animations, movement::{Movement, MovementController, WrapWithinWindow}}, screen::Screen
+    game::{
+        animation::Animations,
+        movement::{Movement, MovementController, WrapWithinWindow},
+    },
+    screen::Screen,
 };
 
 use super::level::{self, Level};
@@ -29,7 +33,7 @@ fn spawn_player(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut graphs: ResMut<Assets<AnimationGraph>>,
-    level: Res<Level>
+    level: Res<Level>,
 ) {
     let mut scene_bundle = SceneBundle {
         transform: Transform::from_translation(INITIAL_POSITION),
@@ -62,7 +66,10 @@ fn spawn_player(
         Player,
         scene_bundle,
         MovementController::default(),
-        Movement { velocity , acceleration:Vec3::ZERO },
+        Movement {
+            velocity,
+            acceleration: Vec3::ZERO,
+        },
         WrapWithinWindow,
         StateScoped(Screen::Playing),
     ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "dev")]
 mod dev_tools;
+mod fps_counter;
 mod game;
 mod screen;
 mod ui;
-mod fps_counter;
 
 use bevy::{
     asset::AssetMetaCheck,

--- a/src/screen/playing.rs
+++ b/src/screen/playing.rs
@@ -3,11 +3,12 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use super::Screen;
-use crate::game::{audio::soundtrack::Soundtrack, spawn::level::SpawnLevel};
+use crate::game::{audio::soundtrack::Soundtrack, spawn::{level::SpawnLevel, player::Player}};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Playing), enter_playing);
     app.add_systems(OnExit(Screen::Playing), exit_playing);
+    app.add_systems(OnTransition{exited: Screen::Playing, entered:Screen::Playing}, reset_level);
 
     app.add_systems(
         Update,
@@ -21,9 +22,19 @@ fn enter_playing(mut commands: Commands) {
     commands.trigger(Soundtrack::Gameplay);
 }
 
-fn exit_playing(mut commands: Commands) {
+fn exit_playing(mut commands: Commands, query: Query<Entity, With<Player>>,) {
     // We could use [`StateScoped`] on the sound playing entites instead.
     commands.trigger(Soundtrack::Disable);
+    for entity in &mut query.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+fn reset_level(mut commands: Commands, query: Query<Entity, With<Player>>) {
+    for entity in &mut query.iter() {
+        commands.entity(entity).despawn();
+    }
+    commands.trigger(SpawnLevel);
 }
 
 fn return_to_title_screen(mut next_screen: ResMut<NextState<Screen>>) {

--- a/src/screen/playing.rs
+++ b/src/screen/playing.rs
@@ -3,12 +3,21 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use super::Screen;
-use crate::game::{audio::soundtrack::Soundtrack, spawn::{level::SpawnLevel, player::Player}};
+use crate::game::{
+    audio::soundtrack::Soundtrack,
+    spawn::{level::SpawnLevel, player::Player},
+};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Playing), enter_playing);
     app.add_systems(OnExit(Screen::Playing), exit_playing);
-    app.add_systems(OnTransition{exited: Screen::Playing, entered:Screen::Playing}, reset_level);
+    app.add_systems(
+        OnTransition {
+            exited: Screen::Playing,
+            entered: Screen::Playing,
+        },
+        reset_level,
+    );
 
     app.add_systems(
         Update,
@@ -22,7 +31,7 @@ fn enter_playing(mut commands: Commands) {
     commands.trigger(Soundtrack::Gameplay);
 }
 
-fn exit_playing(mut commands: Commands, query: Query<Entity, With<Player>>,) {
+fn exit_playing(mut commands: Commands, query: Query<Entity, With<Player>>) {
     // We could use [`StateScoped`] on the sound playing entites instead.
     commands.trigger(Soundtrack::Disable);
     for entity in &mut query.iter() {

--- a/src/screen/title.rs
+++ b/src/screen/title.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::ui::prelude::*;
+use crate::{game::spawn::level::Level, ui::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Title), enter_title);
@@ -36,6 +36,7 @@ fn enter_title(mut commands: Commands) {
 }
 
 fn handle_title_action(
+    mut commands: Commands,
     mut next_screen: ResMut<NextState<Screen>>,
     mut button_query: InteractionQuery<&TitleAction>,
     #[cfg(not(target_family = "wasm"))] mut app_exit: EventWriter<AppExit>,
@@ -43,7 +44,10 @@ fn handle_title_action(
     for (interaction, action) in &mut button_query {
         if matches!(interaction, Interaction::Pressed) {
             match action {
-                TitleAction::Play => next_screen.set(Screen::Playing),
+                TitleAction::Play => {
+                    commands.insert_resource(Level(1));
+                    next_screen.set(Screen::Playing)
+                },
                 TitleAction::Credits => next_screen.set(Screen::Credits),
 
                 #[cfg(not(target_family = "wasm"))]

--- a/src/screen/title.rs
+++ b/src/screen/title.rs
@@ -45,7 +45,7 @@ fn handle_title_action(
         if matches!(interaction, Interaction::Pressed) {
             match action {
                 TitleAction::Play => {
-                    commands.insert_resource(Level(1));
+                    commands.insert_resource(Level::Birth);
                     next_screen.set(Screen::Playing)
                 },
                 TitleAction::Credits => next_screen.set(Screen::Credits),

--- a/src/screen/title.rs
+++ b/src/screen/title.rs
@@ -47,7 +47,7 @@ fn handle_title_action(
                 TitleAction::Play => {
                     commands.insert_resource(Level::Birth);
                     next_screen.set(Screen::Playing)
-                },
+                }
                 TitleAction::Credits => next_screen.set(Screen::Credits),
 
                 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
This PR adds two main things:
- Level changing support. Right now the only different is level 2. You can change levels with 1 & 2 on the keyboard. 1 decreases the level and 2 increases it but this is only for testing purposes.
- Adds some basic functionality for level 2. It has a few issues, for example the camera starts to flicker after some time, I think it's because the velocity is too high.